### PR TITLE
Stories interaction improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,17 +78,15 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "typescript": "^4.2.2",
-    "tailwindcss": "^2.2.15",
-    "@fontsource/ibm-plex-mono": "^4.5.1",
-    "@fontsource/ibm-plex-sans": "^4.5.1",
-    "@fontsource/ibm-plex-serif": "^4.5.0",
-    "@fortawesome/fontawesome-free": "^5.15.4",
     "@babel/plugin-proposal-decorators": "^7.12.1",
     "@babel/plugin-transform-modules-commonjs": "^7.13.8",
     "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.0.0",
+    "@fontsource/ibm-plex-mono": "^4.5.1",
+    "@fontsource/ibm-plex-sans": "^4.5.1",
+    "@fontsource/ibm-plex-serif": "^4.5.0",
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "@testing-library/dom": "^8.7.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.1",
@@ -96,6 +94,7 @@
     "@types/expect-puppeteer": "^4.4.6",
     "@types/jest": "^27.0.1",
     "@types/jest-environment-puppeteer": "^4.4.1",
+    "@types/lodash": "^4.14.177",
     "@types/node": "^16.6.1",
     "@types/puppeteer": "^5.4.4",
     "@types/react": "^17.0.17",
@@ -122,8 +121,10 @@
     "resolve-url-loader": "^4.0.0",
     "sass": "^1.38.1",
     "sass-loader": "^12.1.0",
+    "tailwindcss": "^2.2.15",
     "ts-jest": "^27.0.4",
-    "ts-loader": "^9.2.5"
+    "ts-loader": "^9.2.5",
+    "typescript": "^4.2.2"
   },
   "prettier": {
     "printWidth": 60,

--- a/src/components/controls/SaveControl.tsx
+++ b/src/components/controls/SaveControl.tsx
@@ -17,7 +17,9 @@ export const SaveControl: FC<Props> = observer(
     const [title, icon] = ['Save story', 'fas fa-save'];
     const [isOpen, setIsOpen] = useState(false);
 
-    useHotkeys('shift+s', () => {
+    useHotkeys('shift+s', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
       onClick();
     });
 

--- a/src/components/modals/BaseStoryModal/BaseStoryModal.tsx
+++ b/src/components/modals/BaseStoryModal/BaseStoryModal.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FC,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { SaveStoryI } from './SaveStoryI';
 import { StoryWidgetBody } from './BaseStoryModalBody';
 import { StoryWidgetActions } from './BaseStoryModalActions';
@@ -12,6 +7,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { BaseEventHandler } from '../../../lib/types';
 import { Store } from '../../../lib/store';
 import { observer } from 'mobx-react-lite';
+import { ConfirmDialog } from '../../../lib/utils/Dialog';
 
 export type StoryWidgetSaver = (story: SaveStoryI) => void;
 
@@ -62,18 +58,15 @@ export const BaseStoryWidgetModal: FC<Props> = observer(
       (exstStory) => exstStory.name === story.name,
     );
 
+    const [
+      saveConfirmationRequired,
+      setSaveConfirmationRequired,
+    ] = useState(false);
+
     const handleSave = (e) => {
-      if (isStoryBeingEdited) {
-        if (
-          window.confirm(
-            `Are you sure want to overwrite '${story.name}''`,
-          )
-        ) {
-          storySaver(story);
-        }
-      } else {
-        storySaver(story);
-      }
+      isStoryBeingEdited
+        ? setSaveConfirmationRequired(true)
+        : storySaver(story);
     };
 
     const handleChange =
@@ -121,6 +114,15 @@ export const BaseStoryWidgetModal: FC<Props> = observer(
         <StoryWidgetActions
           handleSave={handleSave}
           handleCancel={handleCancel}
+        />
+
+        <ConfirmDialog
+          title="Overwrite existing story"
+          description={`Are you sure want to overwrite existing «‎${story.name}»‎ story?`}
+          open={saveConfirmationRequired}
+          setOpen={setSaveConfirmationRequired}
+          onConfirm={() => storySaver(story)}
+          onClose={() => setSaveConfirmationRequired(false)}
         />
       </div>
     );

--- a/src/components/modals/BaseStoryModal/BaseStoryModal.tsx
+++ b/src/components/modals/BaseStoryModal/BaseStoryModal.tsx
@@ -54,16 +54,17 @@ export const BaseStoryWidgetModal: FC<Props> = observer(
       }
     }, [defaultStory]);
 
-    const isStoryBeingEdited = store.metadata.stories.some(
-      (exstStory) => exstStory.name === story.name,
-    );
-
     const [
       saveConfirmationRequired,
       setSaveConfirmationRequired,
     ] = useState(false);
 
     const handleSave = (e) => {
+      const isStoryBeingEdited =
+        store.metadata.stories.some(
+          (exstStory) => exstStory.name === story.name,
+        );
+
       isStoryBeingEdited
         ? setSaveConfirmationRequired(true)
         : storySaver(story);

--- a/src/components/modals/BaseStoryModal/BaseStoryModal.tsx
+++ b/src/components/modals/BaseStoryModal/BaseStoryModal.tsx
@@ -1,99 +1,128 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, {
+  FC,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { SaveStoryI } from './SaveStoryI';
 import { StoryWidgetBody } from './BaseStoryModalBody';
 import { StoryWidgetActions } from './BaseStoryModalActions';
 import { StoryWidgetModalHeader } from './BaseStoryModalHeader';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { BaseEventHandler } from '../../../lib/types';
+import { Store } from '../../../lib/store';
+import { observer } from 'mobx-react-lite';
 
 export type StoryWidgetSaver = (story: SaveStoryI) => void;
 
-interface Props {
+type Props = {
   defaultStory?: SaveStoryI;
   storySaver: StoryWidgetSaver;
   handleCancel: BaseEventHandler;
+  store: Store;
   withHeader?: boolean;
-}
+};
 
-export const BaseStoryWidgetModal: FC<Props> = ({
-  defaultStory,
-  storySaver,
-  handleCancel,
-  withHeader = true,
-}) => {
-  useHotkeys(
-    'enter',
-    (e) => {
-      e.stopPropagation();
-      storySaver(story);
-    },
-    {
-      enableOnTags: ['INPUT'],
-    },
-  );
+export const BaseStoryWidgetModal: FC<Props> = observer(
+  ({
+    defaultStory,
+    storySaver,
+    handleCancel,
+    store,
+    withHeader = true,
+  }) => {
+    useHotkeys(
+      'enter',
+      (e) => {
+        e.stopPropagation();
+        handleSave(e);
+      },
+      {
+        enableOnTags: ['INPUT'],
+      },
+    );
 
-  const [story, setStory] = useState<SaveStoryI>({
-    name: '',
-    description: '',
-    tags: {},
-  });
+    const [story, setStory] = useState<SaveStoryI>({
+      name: '',
+      description: '',
+      tags: {},
+    });
 
-  useEffect(() => {
-    if (defaultStory) {
-      setStory({
-        name: defaultStory.name,
-        description: defaultStory.description,
-        tags: Object.assign({}, defaultStory.tags),
-      });
-    }
-  }, [defaultStory]);
+    useEffect(() => {
+      if (defaultStory) {
+        setStory({
+          name: defaultStory.name,
+          description: defaultStory.description,
+          tags: Object.assign({}, defaultStory.tags),
+        });
+      }
+    }, [defaultStory]);
 
-  const handleChange =
-    (field: string, tagKey: number = 0) =>
-    (e) => {
-      field === 'tags'
-        ? setStory({
-            ...story,
-            [field]: {
-              ...story.tags,
-              [tagKey]: e.target.value,
-            },
-          })
-        : setStory({
-            ...story,
-            [field]: e.target.value,
-          });
+    const isStoryBeingEdited = store.metadata.stories.some(
+      (exstStory) => exstStory.name === story.name,
+    );
+
+    const handleSave = (e) => {
+      if (isStoryBeingEdited) {
+        if (
+          window.confirm(
+            `Are you sure want to overwrite '${story.name}''`,
+          )
+        ) {
+          storySaver(story);
+        }
+      } else {
+        storySaver(story);
+      }
     };
 
-  const addTag = (e) => {
-    setStory({
-      ...story,
-      tags: {
-        ...story.tags,
-        [Object.keys(story.tags).length]: '',
-      },
-    });
-  };
+    const handleChange =
+      (field: string, tagKey: number = 0) =>
+      (e) => {
+        field === 'tags'
+          ? setStory({
+              ...story,
+              [field]: {
+                ...story.tags,
+                [tagKey]: e.target.value,
+              },
+            })
+          : setStory({
+              ...story,
+              [field]: e.target.value,
+            });
+      };
 
-  return (
-    <div id="story-modal">
-      {withHeader && (
-        <StoryWidgetModalHeader
+    const addTag = (e) => {
+      setStory({
+        ...story,
+        tags: {
+          ...story.tags,
+          [Object.keys(story.tags).length]: '',
+        },
+      });
+    };
+
+    return (
+      <div id="story-modal">
+        {withHeader && (
+          <StoryWidgetModalHeader
+            story={story}
+            handleCancel={handleCancel}
+          />
+        )}
+        <StoryWidgetBody
           story={story}
+          handleChange={handleChange}
+          addTag={addTag}
+          setStory={setStory}
+          store={store}
+        />
+        <StoryWidgetActions
+          handleSave={handleSave}
           handleCancel={handleCancel}
         />
-      )}
-      <StoryWidgetBody
-        story={story}
-        handleChange={handleChange}
-        addTag={addTag}
-      />
-      <StoryWidgetActions
-        handleSave={(e) => {
-          storySaver(story);
-        }}
-        handleCancel={handleCancel}
-      />
-    </div>
-  );
-};
+      </div>
+    );
+  },
+);

--- a/src/components/modals/BaseStoryModal/BaseStoryModalBody.tsx
+++ b/src/components/modals/BaseStoryModal/BaseStoryModalBody.tsx
@@ -5,6 +5,7 @@ import React, {
   FC,
   SetStateAction,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import { Store } from '../../../lib/store';
@@ -58,6 +59,11 @@ export const StoryWidgetBody: FC<Props> = observer(
       },
     );
 
+    const nameInput = useRef(null);
+    useEffect(() => {
+      nameInput.current.focus();
+    }, []);
+
     useEffect(() => {
       setPossibleMatches({
         ...possibleMatches,
@@ -89,6 +95,7 @@ export const StoryWidgetBody: FC<Props> = observer(
               className={fieldStyle}
               placeholder="descriptive story name"
               value={story.name}
+              ref={nameInput}
             />
             {showMatches &&
               possibleMatches.byName.length > 0 && (

--- a/src/components/modals/BaseStoryModal/BaseStoryModalBody.tsx
+++ b/src/components/modals/BaseStoryModal/BaseStoryModalBody.tsx
@@ -48,7 +48,7 @@ export const StoryWidgetBody: FC<Props> = observer(
         byName: [],
         byDescription: [],
       });
-    const [showMatches, setShowMatches] = useState(true);
+    const [showMatches, setShowMatches] = useState(false);
 
     const nameFuse = new Fuse<Story>(
       store.metadata.stories,
@@ -66,13 +66,15 @@ export const StoryWidgetBody: FC<Props> = observer(
           .map((result) => result.item),
       });
 
-      const matchedStorySelected =
-        possibleMatches.byName.some(
-          (matchedStory) =>
-            matchedStory.name === story.name,
-        );
+      if (possibleMatches.byName.length > 0) {
+        const matchedStorySelected =
+          possibleMatches.byName.some(
+            (matchedStory) =>
+              matchedStory.name === story.name,
+          );
 
-      if (!matchedStorySelected) setShowMatches(true);
+        if (!matchedStorySelected) setShowMatches(true);
+      }
     }, [story]);
 
     return (

--- a/src/components/modals/BaseStoryModal/BaseStoryModalBody.tsx
+++ b/src/components/modals/BaseStoryModal/BaseStoryModalBody.tsx
@@ -1,69 +1,133 @@
-import React, { FC } from 'react';
+import Fuse from 'fuse.js';
+import { observer } from 'mobx-react-lite';
+import React, {
+  Dispatch,
+  FC,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
+import { Store } from '../../../lib/store';
 import {
   baseFieldStyle,
   baseFieldTitleStyle,
 } from '../../../lib/styles';
-import { BaseEventHandler } from '../../../lib/types';
+import {
+  BaseEventHandler,
+  Story,
+} from '../../../lib/types';
 import { Button } from '../../fields/Button';
+import { PossibleMatchesList } from './PossibleMatchesList';
 import { SaveStoryI } from './SaveStoryI';
+
+type StoryModalFieldChangeHandler = (
+  field: string,
+  tagKey?: number,
+) => BaseEventHandler;
 
 interface Props {
   story: SaveStoryI;
-  handleChange: (
-    field: string,
-    tagKey?: number,
-  ) => BaseEventHandler;
+  handleChange: StoryModalFieldChangeHandler;
   addTag: BaseEventHandler;
+  setStory: Dispatch<SetStateAction<SaveStoryI>>;
+  store: Store;
 }
 
 const fieldStyle = `${baseFieldStyle} w-full`;
 const tagFieldStyle = `${baseFieldStyle} w-1/5 rounded-full text-center`;
 
-export const StoryWidgetBody: FC<Props> = ({
-  story,
-  handleChange,
-  addTag,
-}) => {
-  return (
-    <div>
-      <div className="bg-gray-100 px-6 py-2">
-        <div className="flex flex-col my-4 justify-center align-middle text-gray-500 text-xs">
-          <span className={baseFieldTitleStyle}>Name</span>
-          <input
-            onChange={handleChange('name')}
-            className={fieldStyle}
-            placeholder="descriptive story name"
-            value={story.name}
-          />
+type StoryMatches = {
+  byName: Story[];
+  byDescription: Story[];
+};
 
-          <span className={baseFieldTitleStyle}>
-            Description
-          </span>
-          <input
-            onChange={handleChange('description')}
-            type="textarea"
-            className={fieldStyle}
-            placeholder="story description"
-            value={story.description}
-          />
+export const StoryWidgetBody: FC<Props> = observer(
+  ({ story, handleChange, addTag, setStory, store }) => {
+    const [possibleMatches, setPossibleMatches] =
+      useState<StoryMatches>({
+        byName: [],
+        byDescription: [],
+      });
+    const [showMatches, setShowMatches] = useState(true);
 
-          <span className={baseFieldTitleStyle}>Tags</span>
-          <div>
-            {Object.values(story.tags).map((tag, i) => {
-              return (
-                <input
-                  key={i}
-                  onChange={handleChange('tags', i)}
-                  className={tagFieldStyle}
-                  placeholder="story tag"
-                  value={tag}
+    const nameFuse = new Fuse<Story>(
+      store.metadata.stories,
+      {
+        keys: ['name'],
+        threshold: 0.3,
+      },
+    );
+
+    useEffect(() => {
+      setPossibleMatches({
+        ...possibleMatches,
+        byName: nameFuse
+          .search(story.name)
+          .map((result) => result.item),
+      });
+
+      const matchedStorySelected =
+        possibleMatches.byName.some(
+          (matchedStory) =>
+            matchedStory.name === story.name,
+        );
+
+      if (!matchedStorySelected) setShowMatches(true);
+    }, [story]);
+
+    return (
+      <div>
+        <div className="bg-gray-100 px-6 py-2">
+          <div className="flex flex-col my-4 justify-center align-middle text-gray-500 text-xs">
+            <span className={baseFieldTitleStyle}>
+              Name
+            </span>
+            <input
+              onChange={handleChange('name')}
+              className={fieldStyle}
+              placeholder="descriptive story name"
+              value={story.name}
+            />
+            {showMatches &&
+              possibleMatches.byName.length > 0 && (
+                <PossibleMatchesList
+                  possibleMatches={possibleMatches.byName}
+                  setStory={setStory}
+                  setShowMatches={setShowMatches}
                 />
-              );
-            })}
-            <Button symbol="+" clickHandler={addTag} />
+              )}
+
+            <span className={baseFieldTitleStyle}>
+              Description
+            </span>
+            <input
+              onChange={handleChange('description')}
+              type="textarea"
+              className={fieldStyle}
+              placeholder="story description"
+              value={story.description}
+            />
+
+            <span className={baseFieldTitleStyle}>
+              Tags
+            </span>
+            <div>
+              {Object.values(story.tags).map((tag, i) => {
+                return (
+                  <input
+                    key={i}
+                    onChange={handleChange('tags', i)}
+                    className={tagFieldStyle}
+                    placeholder="story tag"
+                    value={tag}
+                  />
+                );
+              })}
+              <Button symbol="+" clickHandler={addTag} />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  },
+);

--- a/src/components/modals/BaseStoryModal/PossibleMatchesList/index.tsx
+++ b/src/components/modals/BaseStoryModal/PossibleMatchesList/index.tsx
@@ -1,0 +1,43 @@
+import React, { Dispatch, SetStateAction, FC } from 'react';
+import { Story } from '../../../../lib/types';
+import { SaveStoryI } from '../SaveStoryI';
+
+interface Props {
+  possibleMatches: Story[];
+  setStory: Dispatch<SetStateAction<SaveStoryI>>;
+  setShowMatches: Dispatch<SetStateAction<boolean>>;
+}
+
+export const PossibleMatchesList: FC<Props> = ({
+  possibleMatches,
+  setStory,
+  setShowMatches,
+}) => {
+  return (
+    <div className="w-full my-4 bg-white rounded-lg shadow-lg lg:w-1/3">
+      <ul className="bg-white rounded-lg border border-gray-200">
+        {possibleMatches.map((possibleMatch, i) => {
+          const clickHandler = (e) => {
+            setStory({
+              name: possibleMatch.name,
+              description: possibleMatch.description,
+              tags: Object.assign({}, possibleMatch.tags),
+            });
+
+            setShowMatches(false);
+          };
+
+          return (
+            <li
+              className="px-4 py-2 border-b border-gray-200 hover:bg-gray-100 hover:text-indigo-700 hover:text-gray-900"
+              key={`${possibleMatch.name}-${i}`}
+              onClick={clickHandler}
+            >
+              {possibleMatch.name}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/src/components/modals/Open/Open.tsx
+++ b/src/components/modals/Open/Open.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { Cookie } from '../../../lib/utils';
 import { Store } from '../../../lib/store';
@@ -6,6 +6,7 @@ import { OpenModalBody } from './OpenBody';
 import { OpenModalActions } from './OpenActions';
 import { BaseModalHeader } from '../BaseModalHeader';
 import { BaseVoidEventHandler } from '../../../lib/types';
+import { ConfirmDialog } from '../../../lib/utils/Dialog';
 
 interface Props {
   store: Store;
@@ -14,6 +15,11 @@ interface Props {
 
 export const OpenModal: FC<Props> = observer(
   ({ store, closeModal }) => {
+    const [
+      clearConfirmationRequired,
+      setClearConfirmationRequired,
+    ] = useState(false);
+
     const handleCancel = (_e) => {
       closeModal();
     };
@@ -35,8 +41,21 @@ export const OpenModal: FC<Props> = observer(
           afterStoryClick={afterStoryClick}
         />
         <OpenModalActions
-          handleClear={handleClear}
+          handleClear={() =>
+            setClearConfirmationRequired(true)
+          }
           handleCancel={handleCancel}
+        />
+
+        <ConfirmDialog
+          title="Clear user stories"
+          description={`Are you sure want to clear all saved stories?`}
+          open={clearConfirmationRequired}
+          setOpen={setClearConfirmationRequired}
+          onConfirm={() => handleClear}
+          onClose={() =>
+            setClearConfirmationRequired(false)
+          }
         />
       </div>
     );

--- a/src/components/modals/Open/OpenBody.tsx
+++ b/src/components/modals/Open/OpenBody.tsx
@@ -17,6 +17,18 @@ interface Props {
 
 export const OpenModalBody: FC<Props> = observer(
   ({ store, afterStoryClick }) => {
+    useHotkeys(
+      'shift+enter',
+      (e) => {
+        e.stopPropagation();
+        currentSearchedStory.current.click();
+      },
+      {
+        enableOnTags: ['INPUT'],
+        enabled: !store.metadata.confirmationRequired,
+      },
+    );
+
     const userStories = store.metadata.stories;
     const currentSearchedStory = useRef(null);
 
@@ -29,18 +41,6 @@ export const OpenModalBody: FC<Props> = observer(
 
     const userHaveSavedStories =
       store.metadata.stories.length !== 0;
-
-    useHotkeys(
-      'enter',
-      (e) => {
-        e.stopPropagation();
-        currentSearchedStory.current.click();
-      },
-      {
-        enableOnTags: ['INPUT'],
-        enabled: !store.metadata.confirmationRequired,
-      },
-    );
 
     return (
       <div>

--- a/src/components/modals/Open/OpenBody.tsx
+++ b/src/components/modals/Open/OpenBody.tsx
@@ -27,17 +27,20 @@ export const OpenModalBody: FC<Props> = observer(
       return userSearchedStories.includes(story as Story);
     };
 
+    const userHaveSavedStories =
+      store.metadata.stories.length !== 0;
+
     useHotkeys(
       'enter',
       (e) => {
         e.stopPropagation();
         currentSearchedStory.current.click();
       },
-      { enableOnTags: ['INPUT'] },
+      {
+        enableOnTags: ['INPUT'],
+        enabled: !store.metadata.confirmationRequired,
+      },
     );
-
-    const userHaveSavedStories =
-      store.metadata.stories.length !== 0;
 
     return (
       <div>

--- a/src/components/modals/Open/OpenBody.tsx
+++ b/src/components/modals/Open/OpenBody.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useRef, useState } from 'react';
 import { Store } from '../../../lib/store';
 import { observer } from 'mobx-react-lite';
 import { StoryGrid } from '../../widgets/DataStory';
@@ -8,6 +8,7 @@ import {
   GenericStory,
   Story,
 } from '../../../lib/types';
+import { useHotkeys } from 'react-hotkeys-hook';
 
 interface Props {
   store: Store;
@@ -17,6 +18,7 @@ interface Props {
 export const OpenModalBody: FC<Props> = observer(
   ({ store, afterStoryClick }) => {
     const userStories = store.metadata.stories;
+    const currentSearchedStory = useRef(null);
 
     const [userSearchedStories, setUserSearchedStories] =
       useState(userStories);
@@ -24,6 +26,15 @@ export const OpenModalBody: FC<Props> = observer(
     const isStorySearched = (story: GenericStory) => {
       return userSearchedStories.includes(story as Story);
     };
+
+    useHotkeys(
+      'enter',
+      (e) => {
+        e.stopPropagation();
+        currentSearchedStory.current.click();
+      },
+      { enableOnTags: ['INPUT'] },
+    );
 
     const userHaveSavedStories =
       store.metadata.stories.length !== 0;
@@ -47,6 +58,8 @@ export const OpenModalBody: FC<Props> = observer(
               stories={userStories.filter(isStorySearched)}
               store={store}
               afterStoryClick={afterStoryClick}
+              currentSearchedStory={currentSearchedStory}
+              visualSelection={true}
             />
           </div>
         </div>

--- a/src/components/modals/Save/Save.tsx
+++ b/src/components/modals/Save/Save.tsx
@@ -1,10 +1,9 @@
-import { Story } from '@data-story-org/core';
 import { observer } from 'mobx-react-lite';
 import React, { FC } from 'react';
 import { Store } from '../../../lib/store';
 import {
   BaseVoidEventHandler,
-  SerializedReactDiagram,
+  DataStory,
 } from '../../../lib/types';
 import { saveStory } from '../../../lib/utils';
 import { BaseModalHeader } from '../BaseModalHeader';
@@ -25,15 +24,15 @@ export const SaveModal: FC<Props> = observer(
     const handleSave = async (story: SaveStoryI) => {
       store.getModel().clearLinkLabels();
 
-      const dataStory = new Story<SerializedReactDiagram>(
+      const dataStory = new DataStory(
         story.name,
         story.description,
         Object.values(story.tags),
         store.getModel().serialize(),
       );
 
-      await saveStory(store, dataStory);
       closeModal();
+      await saveStory(store, dataStory);
     };
 
     return (

--- a/src/components/modals/Save/Save.tsx
+++ b/src/components/modals/Save/Save.tsx
@@ -6,6 +6,7 @@ import {
   BaseVoidEventHandler,
   SerializedReactDiagram,
 } from '../../../lib/types';
+import { saveStory } from '../../../lib/utils';
 import { BaseModalHeader } from '../BaseModalHeader';
 import { BaseStoryWidgetModal } from '../BaseStoryModal';
 import { SaveStoryI } from '../BaseStoryModal/SaveStoryI';
@@ -21,7 +22,7 @@ export const SaveModal: FC<Props> = observer(
       closeModal();
     };
 
-    const handleSave = (story: SaveStoryI) => {
+    const handleSave = async (story: SaveStoryI) => {
       store.getModel().clearLinkLabels();
 
       const dataStory = new Story<SerializedReactDiagram>(
@@ -31,19 +32,8 @@ export const SaveModal: FC<Props> = observer(
         store.getModel().serialize(),
       );
 
-      store.setStories([
-        ...store.metadata.stories,
-        dataStory,
-      ]);
-
-      store.metadata.client
-        .save(dataStory)
-        .then(() => {
-          closeModal();
-        })
-        .catch((error) => {
-          alert('Save error');
-        });
+      await saveStory(store, dataStory);
+      closeModal();
     };
 
     return (
@@ -53,6 +43,7 @@ export const SaveModal: FC<Props> = observer(
           storySaver={handleSave}
           handleCancel={handleCancel}
           withHeader={false}
+          store={store}
         />
       </div>
     );

--- a/src/components/modals/StoryWidget/StoryWidget.tsx
+++ b/src/components/modals/StoryWidget/StoryWidget.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useState } from 'react';
 import { observer } from 'mobx-react-lite';
-import partition from 'lodash/partition';
 import { Store } from '../../../lib/store';
 import {
   GenericStory,

--- a/src/components/widgets/DataStory/Story.tsx
+++ b/src/components/widgets/DataStory/Story.tsx
@@ -1,5 +1,5 @@
 import { observer } from 'mobx-react-lite';
-import React, { FC, useState } from 'react';
+import React, { useState } from 'react';
 import Modal from 'react-modal';
 import { Store } from '../../../lib/store';
 import { GenericStory } from '../../../lib/types';
@@ -20,13 +20,14 @@ interface Props {
 const storyWidgetStyle =
   'cursor-pointer rounded bg-gray-400 hover:shadow-xl overflow-hidden shadow-lg';
 
-export const DataStoryWidget: FC<Props> = observer(
-  ({
-    store,
-    story,
-    storyLoadHandler,
-    isStoryDemo = false,
-  }) => {
+export const DataStoryWidget = observer<
+  Props,
+  HTMLDivElement
+>(
+  (
+    { store, story, storyLoadHandler, isStoryDemo = false },
+    ref,
+  ) => {
     const [isOpen, setIsOpen] = useState(false);
 
     const openModal = () => {
@@ -43,6 +44,7 @@ export const DataStoryWidget: FC<Props> = observer(
       <div
         key={story.name}
         id="data-story"
+        ref={ref}
         className={storyWidgetStyle}
         onClick={
           isOpen
@@ -83,4 +85,5 @@ export const DataStoryWidget: FC<Props> = observer(
       </div>
     );
   },
+  { forwardRef: true },
 );

--- a/src/components/widgets/DataStory/StoryActions.tsx
+++ b/src/components/widgets/DataStory/StoryActions.tsx
@@ -1,8 +1,9 @@
 import { observer } from 'mobx-react-lite';
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { Store } from '../../../lib/store';
 import { BaseVoidEventHandler } from '../../../lib/types';
 import { deleteStory } from '../../../lib/utils';
+import { ConfirmDialog } from '../../../lib/utils/Dialog';
 
 interface Story {
   name: string;
@@ -16,6 +17,11 @@ interface Props {
 
 export const DataStoryWidgetActions: FC<Props> = observer(
   ({ store, story, onEdit }) => {
+    const [
+      deleteConfirmationRequired,
+      setDeleteConfirmationRequired,
+    ] = useState(false);
+
     return (
       <div className="absolute top-0 right-0 m-4">
         <div className="flex space-x-2">
@@ -37,12 +43,20 @@ export const DataStoryWidgetActions: FC<Props> = observer(
               e.preventDefault();
               e.stopPropagation();
 
-              deleteStory(store, story.name);
+              setDeleteConfirmationRequired(true);
             }}
           >
             <i className="fas fa-minus"></i>
           </span>
         </div>
+
+        <ConfirmDialog
+          title="Pernamently delete story"
+          description={`Are ypu sure want to delete «‎${story.name}»‎ story?`}
+          open={deleteConfirmationRequired}
+          setOpen={setDeleteConfirmationRequired}
+          onConfirm={() => deleteStory(store, story.name)}
+        />
       </div>
     );
   },

--- a/src/components/widgets/DataStory/StoryGrid.tsx
+++ b/src/components/widgets/DataStory/StoryGrid.tsx
@@ -13,19 +13,28 @@ interface Props {
   store: Store;
   stories: GenericStory[];
   isDemos?: boolean;
+  visualSelectionStyles?: boolean;
   afterStoryClick?: BaseVoidEventHandler;
+  currentSearchedStory?: RefObject<HTMLDivElement>;
 }
 
 const storyGridStyle =
   'px-10 py-5 grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 gap-5';
+
+const selectedStoryStyle = 'saturate-100';
+const unselectedStoryStyle =
+  'opacity-50 shadow-inner hue-rotate-60';
 
 export const StoryGrid: FC<Props> = observer(
   ({
     store,
     stories,
     isDemos = false,
+    currentSearchedStory = null,
+    visualSelectionStyles = false,
     afterStoryClick = () => {},
   }) => {
+    const [cursor, setCursor] = useState(0);
     const onClick = (name: string) => {
       isDemos
         ? loadDemo(store, name)
@@ -38,13 +47,28 @@ export const StoryGrid: FC<Props> = observer(
     return (
       <div className={storyGridStyle}>
         {stories.map((story, i) => {
+          const selectedPredicate = i == cursor;
+
+          const selected = visualSelectionStyles
+            ? selectedPredicate
+            : true;
+
           return (
-            <div key={`${i}-${story.name}`}>
+            <div
+              key={`${i}-${story.name}`}
+              className={`self-start shadow-2xl hover:opacity-100 hover:shadow-2xl ${
+                selected
+                  ? selectedStoryStyle
+                  : unselectedStoryStyle
+              }
+              `}
+            >
               <DataStoryWidget
                 store={store}
                 story={story}
                 storyLoadHandler={onClick}
                 isStoryDemo={isDemos}
+                ref={selected ? currentSearchedStory : null}
               />
             </div>
           );

--- a/src/components/widgets/DataStory/StoryGrid.tsx
+++ b/src/components/widgets/DataStory/StoryGrid.tsx
@@ -13,7 +13,7 @@ import {
   GenericStory,
 } from '../../../lib/types';
 import { DataStoryWidget } from '../../widgets';
-import { useHotkeys } from 'react-hotkeys-hook';
+import { Options, useHotkeys } from 'react-hotkeys-hook';
 
 interface Props {
   store: Store;
@@ -68,13 +68,19 @@ export const StoryGrid: FC<Props> = observer(
           );
       };
 
+      const hotkeysOptions: Options = {
+        enableOnTags: ['INPUT'],
+        enabled: !store.metadata.confirmationRequired,
+      };
+
       useHotkeys(
         'tab, down',
         (e) => {
           e.preventDefault();
+          e.stopPropagation();
           goNext();
         },
-        { enableOnTags: ['INPUT'] },
+        hotkeysOptions,
         [cursor],
       );
 
@@ -82,9 +88,10 @@ export const StoryGrid: FC<Props> = observer(
         'shift+tab, up',
         (e) => {
           e.preventDefault();
+          e.stopPropagation();
           goPrevious();
         },
-        { enableOnTags: ['INPUT'] },
+        hotkeysOptions,
         [cursor],
       );
     }

--- a/src/lib/store/RootStore.ts
+++ b/src/lib/store/RootStore.ts
@@ -20,6 +20,7 @@ interface Metadata {
   activeStory: string;
   client: Client;
   demos: Story[];
+  confirmationRequired: boolean;
 }
 
 interface Diagram {
@@ -51,6 +52,7 @@ export class Store {
     activeStory: 'Untitled',
     client: ClientFactory((window as any).config),
     demos: [],
+    confirmationRequired: false,
   };
 
   constructor() {
@@ -81,6 +83,7 @@ export class Store {
       setRunning: action.bound,
       setStories: action.bound,
       setDiagramLocked: action.bound,
+      setConfirmRequired: action.bound,
 
       // Getters
       getModel: action.bound,
@@ -96,7 +99,7 @@ export class Store {
   }
 
   addNode(data) {
-		delete data.id; // TODO remove id at availableNodes prep
+    delete data.id; // TODO remove id at availableNodes prep
 
     this.getModel().addNode(
       new NodeModel({
@@ -171,10 +174,7 @@ export class Store {
 
   setPage(name) {
     const alreadyOnPage = this.metadata.page == name;
-    this.metadata.page =
-      alreadyOnPage
-        ? 'Workbench'
-        : name;
+    this.metadata.page = alreadyOnPage ? 'Workbench' : name;
   }
 
   setResults(results) {
@@ -285,6 +285,10 @@ export class Store {
       //@ts-ignore
       state.dragCanvas.config.allowDrag = !locked;
     }
+  }
+
+  setConfirmRequired(required: boolean) {
+    this.metadata.confirmationRequired = required;
   }
 
   getModel(): DiagramModel {

--- a/src/lib/types/DataStory.ts
+++ b/src/lib/types/DataStory.ts
@@ -1,6 +1,8 @@
 import { Story as DefaultStory } from '@data-story-org/core';
 import { SerializedReactDiagram } from './SerializedReactDiagram';
 
+export class DataStory extends DefaultStory<SerializedReactDiagram> {}
+
 export type Story = DefaultStory<SerializedReactDiagram>;
 
 export type DemoStory = DefaultStory;

--- a/src/lib/utils/Dialog.tsx
+++ b/src/lib/utils/Dialog.tsx
@@ -80,8 +80,9 @@ export const ConfirmDialog: FC<Props> = ({
   );
 
   useHotkeys(
-    'left, right',
+    'left, right, shift+tab, tab',
     (e) => {
+      e.preventDefault();
       e.stopPropagation();
       switch (currentButton) {
         case 'Cancel':

--- a/src/lib/utils/Dialog.tsx
+++ b/src/lib/utils/Dialog.tsx
@@ -1,0 +1,139 @@
+import React, {
+  Dispatch,
+  FC,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Options, useHotkeys } from 'react-hotkeys-hook';
+import { BaseVoidEventHandler } from '../types';
+
+interface Props {
+  title: string;
+  description: string;
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  onConfirm?: BaseVoidEventHandler;
+  onClose?: BaseVoidEventHandler;
+}
+
+type DialogButton = 'Confirm' | 'Cancel';
+
+export const ConfirmDialog: FC<Props> = ({
+  title = 'Confirm',
+  description = 'Are you sure?',
+  open,
+  setOpen,
+  onConfirm = () => {},
+  onClose = () => {},
+}) => {
+  let cancelButtonRef = useRef(null);
+  let confirmButtonRef = useRef(null);
+  const [currentButton, setCurrentButton] =
+    useState<DialogButton>('Cancel');
+
+  useEffect(() => {
+    open && cancelButtonRef.current.focus();
+  }, [open]);
+
+  const confirmationHandler = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setOpen(false);
+
+    onConfirm();
+  };
+
+  const cancelationHandler = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setOpen(false);
+
+    onClose();
+  };
+
+  const hotkeysOptions: Options = {
+    enabled: open,
+    enableOnContentEditable: false,
+    enableOnTags: [],
+  };
+
+  useHotkeys(
+    'enter',
+    (e) => {
+      e.stopPropagation();
+      currentButton === 'Confirm'
+        ? confirmationHandler(e)
+        : cancelationHandler(e);
+    },
+    hotkeysOptions,
+  );
+
+  useHotkeys(
+    'left, right',
+    (e) => {
+      e.stopPropagation();
+      switch (currentButton) {
+        case 'Cancel':
+          setCurrentButton('Confirm');
+          confirmButtonRef.current.focus();
+          break;
+        case 'Confirm':
+          setCurrentButton('Cancel');
+          cancelButtonRef.current.focus();
+          break;
+      }
+    },
+    hotkeysOptions,
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed z-10 inset-0 overflow-y-auto">
+      <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+        <span
+          className="hidden sm:inline-block sm:align-middle sm:h-screen"
+          aria-hidden="true"
+        >
+          &#8203;
+        </span>
+        <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-2xl drop-shadow-2xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div className="sm:flex sm:items-start">
+              <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                <h3 className="text-lg leading-6 font-medium text-gray-900">
+                  {title}
+                </h3>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    {description}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+            <button
+              type="button"
+              className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
+              onClick={confirmationHandler}
+              ref={confirmButtonRef}
+            >
+              {title}
+            </button>
+            <button
+              type="button"
+              className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+              onClick={cancelationHandler}
+              ref={cancelButtonRef}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/utils/Dialog.tsx
+++ b/src/lib/utils/Dialog.tsx
@@ -8,6 +8,8 @@ import React, {
 } from 'react';
 import { Options, useHotkeys } from 'react-hotkeys-hook';
 import { BaseVoidEventHandler } from '../types';
+import Modal from 'react-modal';
+import { modalDialogStyle } from './modalStyle';
 import { useStore } from '../store';
 
 interface Props {
@@ -72,6 +74,7 @@ export const ConfirmDialog: FC<Props> = ({
     'enter',
     (e) => {
       e.stopPropagation();
+      e.preventDefault();
       currentButton === 'Confirm'
         ? confirmationHandler(e)
         : cancelationHandler(e);
@@ -101,49 +104,57 @@ export const ConfirmDialog: FC<Props> = ({
   if (!open) return null;
 
   return (
-    <div className="fixed z-10 inset-0 overflow-y-auto">
-      <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        <span
-          className="hidden sm:inline-block sm:align-middle sm:h-screen"
-          aria-hidden="true"
-        >
-          &#8203;
-        </span>
-        <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-2xl drop-shadow-2xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-            <div className="sm:flex sm:items-start">
-              <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                <h3 className="text-lg leading-6 font-medium text-gray-900">
-                  {title}
-                </h3>
-                <div className="mt-2">
-                  <p className="text-sm text-gray-500">
-                    {description}
-                  </p>
+    <Modal
+      isOpen={true}
+      show={true}
+      onRequestClose={cancelationHandler}
+      style={modalDialogStyle}
+      closeTimeoutMS={250}
+    >
+      <div className="fixed z-10 inset-0 overflow-y-auto">
+        <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+          <span
+            className="hidden sm:inline-block sm:align-middle sm:h-screen"
+            aria-hidden="true"
+          >
+            &#8203;
+          </span>
+          <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-2xl drop-shadow-2xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+            <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+              <div className="sm:flex sm:items-start">
+                <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                  <h3 className="text-lg leading-6 font-medium text-gray-900">
+                    {title}
+                  </h3>
+                  <div className="mt-2">
+                    <p className="text-sm text-gray-500">
+                      {description}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-            <button
-              type="button"
-              className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
-              onClick={confirmationHandler}
-              ref={confirmButtonRef}
-            >
-              {title}
-            </button>
-            <button
-              type="button"
-              className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
-              onClick={cancelationHandler}
-              ref={cancelButtonRef}
-            >
-              Cancel
-            </button>
+            <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+              <button
+                type="button"
+                className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
+                onClick={confirmationHandler}
+                ref={confirmButtonRef}
+              >
+                {title}
+              </button>
+              <button
+                type="button"
+                className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+                onClick={cancelationHandler}
+                ref={cancelButtonRef}
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };

--- a/src/lib/utils/Dialog.tsx
+++ b/src/lib/utils/Dialog.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { Options, useHotkeys } from 'react-hotkeys-hook';
 import { BaseVoidEventHandler } from '../types';
+import { useStore } from '../store';
 
 interface Props {
   title: string;
@@ -28,13 +29,21 @@ export const ConfirmDialog: FC<Props> = ({
   onConfirm = () => {},
   onClose = () => {},
 }) => {
+  const store = useStore();
+
   let cancelButtonRef = useRef(null);
   let confirmButtonRef = useRef(null);
   const [currentButton, setCurrentButton] =
     useState<DialogButton>('Cancel');
 
   useEffect(() => {
-    open && cancelButtonRef.current.focus();
+    if (open) {
+      store.setConfirmRequired(true);
+    }
+
+    return () => {
+      store.setConfirmRequired(false);
+    };
   }, [open]);
 
   const confirmationHandler = (e) => {

--- a/src/lib/utils/modalStyle.ts
+++ b/src/lib/utils/modalStyle.ts
@@ -22,3 +22,14 @@ export const modalStyle = {
     backgroundColor: 'rgba(0, 0, 0, 0.75)',
   },
 };
+
+export const modalDialogStyle = {
+  ...modalStyle,
+  content: {
+    ...modalStyle.content,
+    top: 'auto',
+    left: 'auto',
+    padding: 'auto',
+    backgroundColor: 'transparent',
+  },
+};

--- a/src/lib/utils/stories.ts
+++ b/src/lib/utils/stories.ts
@@ -31,14 +31,8 @@ export const deleteStory = (
   store: Store,
   storyName: string,
 ) => {
-  if (window.confirm(`Delete the '${storyName} story?'`)) {
-    try {
-      store.metadata.client.delete(storyName);
-
-      const withoutDeletedStory =
-        store.metadata.stories.filter(
-          (story) => story.name !== storyName,
-        );
+  try {
+    store.metadata.client.delete(storyName);
 
       store.setStories(withoutDeletedStory);
     } catch (e) {

--- a/src/lib/utils/stories.ts
+++ b/src/lib/utils/stories.ts
@@ -34,13 +34,17 @@ export const deleteStory = (
   try {
     store.metadata.client.delete(storyName);
 
-      store.setStories(withoutDeletedStory);
-    } catch (e) {
-      alert(
-        `Could not delete story ${storyName}. See console for details.`,
+    const withoutDeletedStory =
+      store.metadata.stories.filter(
+        (story) => story.name !== storyName,
       );
-      console.error(e);
-    }
+
+    store.setStories(withoutDeletedStory);
+  } catch (e) {
+    alert(
+      `Could not delete story ${storyName}. See console for details.`,
+    );
+    console.error(e);
   }
 };
 
@@ -104,6 +108,7 @@ export const editStory = async (
       name: story.name,
       description: story.description,
       tags: story.tags,
+      diagram: story.diagram,
     };
 
     store.setStories([...stories, updatedStory]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,6 +2196,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/lodash@^4.14.177":
+  version "4.14.177"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.177.tgz#f70c0d19c30fab101cad46b52be60363c43c4578"
+  integrity sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"


### PR DESCRIPTION
# Stories interaction improvements


## Updates


### Types

-   DataStory alias for Story type over SerializedReactDiagram
-   lodash types installed


### StoryGrid


#### Visual selection

StoryGrid now supports displaying of stories with visual selection and navigation through them via hotkeys

-   <kbd>down</kbd> and <kbd>tab</kbd> *to navigate next story*
-   <kbd>up</kbd> and <kbd>shift</kbd> + <kbd>tab</kbd> *to navigate previous story*


#### currentSearchedStory ref

Story grid now supports specifying ref for the user selected story

So we can pass ref from parent component, and then define interactions over current selected story as for example use <kbd>Shift</kbd> + <kbd>Enter</kbd> *to open selected story*

```js
const Component = () => {
  const currentSearchedStory = useRef(null);

  useHotkeys('shift+enter', () => {
    currentSearchedStory.current.click();
  });

  return (
    <StoryGrid
      ...
      currentSearchedStory={currentSearchedStory}
      visualSelection={true}
    />
  );
};
```


### StoryModal

Now when story names is being edited, user will see a list of stories with matching names proposing to load them into the modal 

![2021-11-27_18-11-48](https://user-images.githubusercontent.com/49302467/143688727-1082e3bd-1ebd-42e3-93c2-0944e6251153.png)

### StoryActions

Separation of edit actions by whether they save diagram

> Save 

Opens story modal and saves current diagram after confirmation

> Edit
 
Opens story modal without diagram saving, but just story editing 

![2021-11-28_16-23-22](https://user-images.githubusercontent.com/49302467/143780783-945aab50-df1c-4599-949c-50697900a903.png)

### ConfirmDialog

Component for displaying confirm dialog&rsquo;s replacing the window.confirm

new confirmation dialog used in a few new places:

-   when story overwrites existing one
-   when deleting story
-   when clearing all user stories

![2021-11-28_20-25-29](https://user-images.githubusercontent.com/49302467/143781029-d6ee5fc5-d2fa-4bc0-aa42-8fd7287f7057.png)



### Stories helpers

All logic for saving or editing stories now takes place in utils/stories helpers instead of separate functions in the modal components.


## Visual overview of the changes


### Saving to existing stories
![2021-11-27-15:17:10_minimized](https://user-images.githubusercontent.com/49302467/143688761-a256806d-e39b-496c-84eb-6b1a1ba2227d.gif)



### Visual selection in OpenBody
![2021-11-27-17:26:06](https://user-images.githubusercontent.com/49302467/143688763-ac904d78-1fee-423e-8407-dc6418947368.gif)


### Confirm Dialogs
![2021-11-27-17:35:07](https://user-images.githubusercontent.com/49302467/143688768-f8baaec9-8571-46ce-b5d8-3e27f8da969e.gif)
